### PR TITLE
Update UL IDs

### DIFF
--- a/analysis/utils/ids.py
+++ b/analysis/utils/ids.py
@@ -265,11 +265,11 @@ def isTightPhoton(pt, tight_id, year):
     # Tight photon use medium ID, as in monojet
     mask = Mask(pt)
     if year == "2016":
-        mask = (pt > 200) & (tight_id >= 2)
+        mask = (pt > 200) & (tight_id == 3)
     elif year == "2017":
-        mask = (pt > 230) & ((tight_id & 2) == 2)
+        mask = (pt > 230) & (tight_id == 3)
     elif year == "2018":
-        mask = (pt > 230) & ((tight_id & 2) == 2)
+        mask = (pt > 230) & (tight_id == 3)
     return mask
 
 

--- a/analysis/utils/ids.py
+++ b/analysis/utils/ids.py
@@ -238,13 +238,9 @@ def isTightPhoton(pt, tight_id, year):
     return mask
 
 ######
-## Jet
-## https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL
-## https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetIDUL
-## tight working point including lepton veto (TightLepVeto)
-######
-######
 ## Fatjet
+## https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL
+## Tight working point including lepton veto (TightLepVeto)
 ######
 def isGoodFatJet(pt, eta, jet_id, nhf, chf):
     mask = (
@@ -254,18 +250,40 @@ def isGoodFatJet(pt, eta, jet_id, nhf, chf):
     )
     return mask
 
-def isGoodJet(pt, eta, jet_id, pu_id):
-    # Jet ID flags bit1 is loose (always false in 2017 since it does not
-    # exist), bit2 is tight, bit3 is tightLepVeto
-    # POG use tight jetID as a standart JetID
+######
+## Jet
+## https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL
+## Tight working point including lepton veto (TightLepVeto)
+##
+## For Jet ID flags, bit1 is Loose (always false in 2017 since it does not
+## exist), bit2 is Tight, bit3 is TightLepVeto. The POG recommendation is to
+## use Tight Jet ID as the standard Jet ID.
+######
+## PileupJetID
+## https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetIDUL
+## Using Loose Pileup ID
+##
+## Note: There is a bug in 2016 UL in which bit values for Loose and Tight Jet
+## Pileup IDs are accidentally flipped relative to 2017 UL and 2018 UL.
+##
+## For 2016 UL,
+## Jet_puId = (passtightID*4 + passmediumID*2 + passlooseID*1).
+##
+## For 2017 UL and 2018 UL,
+## Jet_puId = (passlooseID*4 + passmediumID*2 + passtightID*1).
+######
+def isGoodJet(pt, eta, jet_id, pu_id, year):
     mask = (
         pt>30 &
         abs(eta)<2.4 &
-        (jet_id&6)==6 # & nhf<0.8 & chf>0.1 & nef<0.99 & cef<0.99
+        (jet_id&6)==6
     )
-    # https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetID, using loose wp
-    mask = ((pt>=50) & mask) |
-           ((pt<50) & mask & (pu_id&4)==4)
+    if year=='2016':
+        mask = ((pt>=50) & mask) | ((pt<50) & mask & (pu_id&1)==1)
+    elif year=='2017':
+        mask = ((pt>=50) & mask) | ((pt<50) & mask & (pu_id&4)==4)
+    elif year=='2018':
+        mask = ((pt>=50) & mask) | ((pt<50) & mask & (pu_id&4)==4)
     return mask
 
 ######

--- a/analysis/utils/ids.py
+++ b/analysis/utils/ids.py
@@ -4,68 +4,157 @@ import uproot
 import numpy as np
 from coffea.util import save
 
+def Mask(pt):
+    # Just a complicated way to initialize a jagged array with the needed shape
+    # to True
+    return ~(pt==np.nan)
+
 ######
 ## Electron
-## Electron_cutBased  Int_t   cut-based ID Fall17 V2 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
+## Electron_cutBased  Int_t  cut-based ID Fall17 V2 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
 ## https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
 ## loose_electron: loose id, tight_electron: tight id
 ######
-def isLooseElectron(pt,eta,dxy,dz,veto_id,year):
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+def isLooseElectron(pt, eta, dxy, dz, loose_id, year):
+    mask = Mask(pt)
     if year=='2016':
-        mask = ((pt>10)&(abs(eta)<1.4442)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(veto_id>=2)) | ((pt>10)&(abs(eta)>1.5660)&(abs(eta)<2.5)&(abs(dxy)<0.1)&(abs(dz)<0.2)&(veto_id>=2))
+        mask = (
+            pt>10 &
+            abs(eta)<1.4442 &
+            abs(dxy)<0.05 & abs(dz)<0.1 & loose_id>=2
+        ) | (
+            pt>10 &
+            abs(eta)>1.5660 & abs(eta)<2.5 &
+            abs(dxy)<0.1 & abs(dz)<0.2 & loose_id>=2
+        )
     elif year=='2017':
-        mask = ((pt>10)&(abs(eta)<1.4442)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(veto_id>=2)) | ((pt>10)&(abs(eta)>1.5660)&(abs(eta)<2.5)&(abs(dxy)<0.1)&(abs(dz)<0.2)&(veto_id>=2))
+        mask = (
+            pt>10 &
+            abs(eta)<1.4442 &
+            abs(dxy)<0.05 & abs(dz)<0.1 & loose_id>=2
+        ) | (
+            pt>10 &
+            abs(eta)>1.5660 & abs(eta)<2.5 &
+            abs(dxy)<0.1 & abs(dz)<0.2 & loose_id>=2
+        )
     elif year=='2018':
-        mask = ((pt>10)&(abs(eta)<1.4442)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(veto_id>=2)) | ((pt>10)&(abs(eta)>1.5660)&(abs(eta)<2.5)&(abs(dxy)<0.1)&(abs(dz)<0.2)&(veto_id>=2))
+        mask = (
+            pt>10 &
+            abs(eta)<1.4442 &
+            abs(dxy)<0.05 & abs(dz)<0.1 & loose_id>=2
+        ) | (
+            pt>10 &
+            abs(eta)>1.5660 & abs(eta)<2.5 &
+            abs(dxy)<0.1 & abs(dz)<0.2 & loose_id>=2
+        )
     return mask
 
 #2017/18 pT thresholds adjusted to match monojet, using dedicated ID SFs
-def isTightElectron(pt,eta,dxy,dz,tight_id,year):
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
-    if year=='2016':
-        mask = ((pt>40)&(abs(eta)<1.4442)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(tight_id==4)) | ((pt>40)&(abs(eta)>1.5660)&(abs(eta)<2.5)&(abs(dxy)<0.1)&(abs(dz)<0.2)&(tight_id==4)) # Trigger: HLT_Ele27_WPTight_Gsf_v
-    elif year=='2017':
-        mask = ((pt>40)&(abs(eta)<1.4442)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(tight_id==4)) | ((pt>40)&(abs(eta)>1.5660)&(abs(eta)<2.5)&(abs(dxy)<0.1)&(abs(dz)<0.2)&(tight_id==4)) # Trigger: HLT_Ele35_WPTight_Gsf_v
-    elif year=='2018':
-        mask = ((pt>40)&(abs(eta)<1.4442)&(abs(dxy)<0.05)&(abs(dz)<0.1)&(tight_id==4)) | ((pt>40)&(abs(eta)>1.5660)&(abs(eta)<2.5)&(abs(dxy)<0.1)&(abs(dz)<0.2)&(tight_id==4)) # Trigger: HLT_Ele32_WPTight_Gsf_v
+def isTightElectron(pt, eta, dxy, dz, tight_id, year):
+    mask = Mask(pt)
+    if year=='2016': # Trigger: HLT_Ele27_WPTight_Gsf_v
+        mask = (
+            pt>40 &
+            abs(eta)<1.4442 &
+            abs(dxy)<0.05 & abs(dz)<0.1 & tight_id==4
+        ) | (
+            pt>40 &
+            abs(eta)>1.5660 & abs(eta)<2.5 &
+            abs(dxy)<0.1 & abs(dz)<0.2 & tight_id==4
+        )
+    elif year=='2017': # Trigger: HLT_Ele35_WPTight_Gsf_v
+        mask = (
+            pt>40 &
+            abs(eta)<1.4442 &
+            abs(dxy)<0.05 & abs(dz)<0.1 & tight_id==4
+        ) | (
+            pt>40 &
+            abs(eta)>1.5660 & abs(eta)<2.5 &
+            abs(dxy)<0.1 & abs(dz)<0.2 & tight_id==4
+        )
+    elif year=='2018': # Trigger: HLT_Ele32_WPTight_Gsf_v
+        mask = (
+            pt>40 &
+            abs(eta)<1.4442 &
+            abs(dxy)<0.05 & abs(dz)<0.1 & tight_id==4
+        ) | (
+            pt>40 &
+            abs(eta)>1.5660 & abs(eta)<2.5 &
+            abs(dxy)<0.1 & abs(dz)<0.2 & tight_id==4
+        )
     return mask
 
 #######
 ## Muon
 ## https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonSelection#Muon_Isolation
 #######
-def isLooseMuon(pt,eta,iso,loose_id,year):
+def isLooseMuon(pt, eta, iso, loose_id, year):
     #dxy and dz cuts are missing from med_id; loose isolation is 0.25
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+    mask = Mask(pt)
     if year=='2016':
-        mask = (pt>20)&(abs(eta)<2.4)&(loose_id>0)&(iso<0.25)
+        mask = (
+            pt>20 &
+            abs(eta)<2.4 &
+            loose_id>0 & iso<0.25
+        )
     elif year=='2017':
-        mask = (pt>20)&(abs(eta)<2.4)&(loose_id>0)&(iso<0.25)
+        mask = (
+            pt>20 &
+            abs(eta)<2.4 &
+            loose_id>0 & iso<0.25
+        )
     elif year=='2018':
-        mask = (pt>15)&(abs(eta)<2.4)&(loose_id>0)&(iso<0.25)
+        mask = (
+            pt>15 &
+            abs(eta)<2.4 &
+            loose_id>0 & iso<0.25
+        )
     return mask
 
-def isTightMuon(pt,eta,iso,tight_id,year):
+def isTightMuon(pt, eta, iso, tight_id, year):
     #dxy and dz cuts are baked on tight_id; tight isolation is 0.15
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+    mask = Mask(pt)
     if year=='2016':
-        mask = (pt>30)&(abs(eta)<2.4)&(tight_id)&(iso<0.15)
+        mask = (
+            pt>30 &
+            abs(eta)<2.4 &
+            tight_id & iso<0.15
+        )
     elif year=='2017':
-        mask = (pt>30)&(abs(eta)<2.4)&(tight_id)&(iso<0.15)
+        mask = (
+            pt>30 &
+            abs(eta)<2.4 &
+            tight_id & iso<0.15
+        )
     elif year=='2018':
-        mask = (pt>30)&(abs(eta)<2.4)&(tight_id)&(iso<0.15)
+        mask = (
+            pt>30 &
+            abs(eta)<2.4 &
+            tight_id & iso<0.15
+        )
     return mask
 
-def isSoftMuon(pt,eta,iso,tight_id,year):
+def isSoftMuon(pt, eta, iso, tight_id, year):
     #dxy and dz cuts are baked on tight_id; tight isolation is 0.15
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+    mask = Mask(pt)
     if year=='2016':
-        mask = (pt>5)&(abs(eta)<2.4)&(tight_id)&(iso>0.15)
+        mask = (
+            pt>5 &
+            abs(eta)<2.4 &
+            tight_id & iso>0.15
+        )
     elif year=='2017':
-        mask = (pt>5)&(abs(eta)<2.4)&(tight_id)&(iso>0.15)
+        mask = (
+            pt>5 &
+            abs(eta)<2.4 &
+            tight_id & iso>0.15
+        )
     elif year=='2018':
-        mask = (pt>5)&(abs(eta)<2.4)&(tight_id)&(iso>0.15)
+        mask = (
+            pt>5 &
+            abs(eta)<2.4 &
+            tight_id & iso>0.15
+        )
     return mask
 
 ######
@@ -73,16 +162,30 @@ def isSoftMuon(pt,eta,iso,tight_id,year):
 ## Tau is not used for hadronic monotop
 ######
 #bitmask 1 = VVLoose, 2 = VLoose, 4 = Loose, 8 = Medium, 16 = Tight, 32 = VTight, 64 = VVTight
-def isLooseTau(pt,eta,decayMode,decayModeDMs,ide,idj,idm,year):
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+def isLooseTau(pt, eta, decayMode, decayModeDMs, ide, idj, idm, year):
+    mask = Mask(pt)
     if year=='2016':
-        mask = (pt>20)&(abs(eta)<2.3)&~(decayMode==5)&~(decayMode==6)&(decayModeDMs)&((ide&16)==16)&((idj&4)==4)&((idm&2)==2)
+        mask = (
+            pt>20 &
+            abs(eta)<2.3 &
+            ~(decayMode==5) & ~(decayMode==6) & decayModeDMs &
+            (ide&16)==16 & (idj&4)==4 & (idm&2)==2
+        )
     elif year=='2017':
-        mask = (pt>20)&(abs(eta)<2.3)&~(decayMode==5)&~(decayMode==6)&(decayModeDMs)&((ide&16)==16)&((idj&4)==4)&((idm&2)==2)
+        mask = (
+            pt>20 &
+            abs(eta)<2.3 &
+            ~(decayMode==5) & ~(decayMode==6) & decayModeDMs &
+            (ide&16)==16 & (idj&4)==4 & (idm&2)==2
+        )
     elif year=='2018':
-        mask = (pt>20)&(abs(eta)<2.3)&~(decayMode==5)&~(decayMode==6)&(decayModeDMs)&((ide&16)==16)&((idj&4)==4)&((idm&2)==2)
+        mask = (
+            pt>20 &
+            abs(eta)<2.3 &
+            ~(decayMode==5) & ~(decayMode==6) & decayModeDMs &
+            (ide&16)==16 & (idj&4)==4 & (idm&2)==2
+        )
     return mask
-
 
 ######
 ## Photon
@@ -90,29 +193,49 @@ def isLooseTau(pt,eta,decayMode,decayModeDMs,ide,idj,idm,year):
 #Photon_cutBased Int_t "cut-based spring16-V2p2 ID (0:fail, 1:loose, 2:medium, 3:tight" for 2016 NanoAOD
 #Photon_cutBasedBitmap  Int_t   cut-based ID bitmap, 2^(0:loose, 1:medium, 2:tight)
 #Photon IDs:  https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2?rev=36
-def isLoosePhoton(pt,eta,loose_id,year):
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+def isLoosePhoton(pt, eta, loose_id, year):
+    mask = Mask(pt)
     if year=='2016':
-        mask = (pt>20)&~((abs(eta)>1.4442)&(abs(eta)<1.5660))&(abs(eta)<2.5)&(loose_id>=1)
+        mask = (
+            pt>20 &
+            ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
+            loose_id>=1
+        )
     elif year=='2017':
-        mask = (pt>20)&~((abs(eta)>1.4442)&(abs(eta)<1.5660))&(abs(eta)<2.5)&((loose_id&1)==1)
+        mask = (
+            pt>20 &
+            ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
+            (loose_id&1)==1
+        )
     elif year=='2018':
-        mask = (pt>20)&~((abs(eta)>1.4442)&(abs(eta)<1.5660))&(abs(eta)<2.5)&((loose_id&1)==1)
+        mask = (
+            pt>20 &
+            ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
+            (loose_id&1)==1
+        )
     return mask
 
-def isTightPhoton(pt,tight_id,year):
+def isTightPhoton(pt, tight_id, year):
     #isScEtaEB is used (barrel only), so no eta requirement
     #2017/18 pT requirement adjusted to match monojet, using dedicated ID SFs
     #Tight photon use medium ID, as in monojet
-    mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
+    mask = Mask(pt)
     if year=='2016':
-        mask = (pt>200)&(tight_id>=2)
+        mask = (
+            pt>200 &
+            tight_id>=2
+        )
     elif year=='2017':
-        mask = (pt>230)&((tight_id&2)==2) #
+        mask = (
+            pt>230 &
+            (tight_id&2)==2
+        )
     elif year=='2018':
-        mask = (pt>230)&((tight_id&2)==2) #
+        mask = (
+            pt>230 &
+            (tight_id&2)==2
+        )
     return mask
-
 
 ######
 ## Jet
@@ -124,27 +247,38 @@ def isTightPhoton(pt,tight_id,year):
 ## Fatjet
 ######
 def isGoodFatJet(pt, eta, jet_id, nhf, chf):
-    mask = (pt > 160) & (abs(eta)<2.4) & ((jet_id&6)==6) & (nhf<0.8) & (chf>0.1) 
+    mask = (
+        pt>160 &
+        abs(eta)<2.4) &
+        (jet_id&6)==6 & nhf<0.8 & chf>0.1
+    )
     return mask
-
-
-#Jet ID flags bit1 is loose (always false in 2017 since it does not exist), bit2 is tight, bit3 is tightLepVeto
-#POG use tight jetID as a standart JetID 
 
 def isGoodJet(pt, eta, jet_id, pu_id):
-    mask = (pt>30) & (abs(eta)<2.4) & ((jet_id&6)==6) # & (nhf<0.8) & (chf>0.1)# & (nef<0.99) & (cef<0.99)
-    mask = ((pt>=50)&mask) | ((pt<50)&mask&((pu_id&4)==4)) #https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetID, using loose wp
+    # Jet ID flags bit1 is loose (always false in 2017 since it does not
+    # exist), bit2 is tight, bit3 is tightLepVeto
+    # POG use tight jetID as a standart JetID
+    mask = (
+        pt>30 &
+        abs(eta)<2.4 &
+        (jet_id&6)==6 # & nhf<0.8 & chf>0.1 & nef<0.99 & cef<0.99
+    )
+    # https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetID, using loose wp
+    mask = ((pt>=50) & mask) |
+           ((pt<50) & mask & (pu_id&4)==4)
     return mask
-
 
 ######
 ## HEM
 ######
 
 def isHEMJet(pt, eta, phi):
-    mask = (pt>30) & ((eta>-3.0)&(eta<-1.3)) & ((phi>-1.57)&(phi<-0.87))
+    mask = (
+        pt>30 &
+        eta>-3.0 & eta<-1.3 &
+        phi>-1.57 & phi<-0.87
+    )
     return mask
-
 
 
 ids = {}

--- a/analysis/utils/ids.py
+++ b/analysis/utils/ids.py
@@ -1,13 +1,14 @@
 import awkward
 import uproot
-#import uproot_methods
 import numpy as np
 from coffea.util import save
+
 
 def Mask(pt):
     # Just a complicated way to initialize a jagged array with the needed shape
     # to True
-    return ~(pt==np.nan)
+    return ~(pt == np.nan)
+
 
 ######
 ## Electron
@@ -16,74 +17,107 @@ def Mask(pt):
 ## https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
 ######
 
+
 def isLooseElectron(pt, eta, dxy, dz, loose_id, year):
     mask = Mask(pt)
-    if year=='2016':
+    if year == "2016":
         mask = (
-            pt>10 &
-            abs(eta)<1.4442 &
-            abs(dxy)<0.05 & abs(dz)<0.1 & loose_id>=2
+            (pt > 10)
+            & (abs(eta) < 1.4442)
+            & (abs(dxy) < 0.05)
+            & (abs(dz) < 0.1)
+            & (loose_id >= 2)
         ) | (
-            pt>10 &
-            abs(eta)>1.5660 & abs(eta)<2.5 &
-            abs(dxy)<0.1 & abs(dz)<0.2 & loose_id>=2
+            (pt > 10)
+            & (abs(eta) > 1.5660)
+            & (abs(eta) < 2.5)
+            & (abs(dxy) < 0.1)
+            & (abs(dz) < 0.2)
+            & (loose_id >= 2)
         )
-    elif year=='2017':
+    elif year == "2017":
         mask = (
-            pt>10 &
-            abs(eta)<1.4442 &
-            abs(dxy)<0.05 & abs(dz)<0.1 & loose_id>=2
+            (pt > 10)
+            & (abs(eta) < 1.4442)
+            & (abs(dxy) < 0.05)
+            & (abs(dz) < 0.1)
+            & (loose_id >= 2)
         ) | (
-            pt>10 &
-            abs(eta)>1.5660 & abs(eta)<2.5 &
-            abs(dxy)<0.1 & abs(dz)<0.2 & loose_id>=2
+            (pt > 10)
+            & (abs(eta) > 1.5660)
+            & (abs(eta) < 2.5)
+            & (abs(dxy) < 0.1)
+            & (abs(dz) < 0.2)
+            & (loose_id >= 2)
         )
-    elif year=='2018':
+    elif year == "2018":
         mask = (
-            pt>10 &
-            abs(eta)<1.4442 &
-            abs(dxy)<0.05 & abs(dz)<0.1 & loose_id>=2
+            (pt > 10)
+            & (abs(eta) < 1.4442)
+            & (abs(dxy) < 0.05)
+            & (abs(dz) < 0.1)
+            & (loose_id >= 2)
         ) | (
-            pt>10 &
-            abs(eta)>1.5660 & abs(eta)<2.5 &
-            abs(dxy)<0.1 & abs(dz)<0.2 & loose_id>=2
+            (pt > 10)
+            & (abs(eta) > 1.5660)
+            & (abs(eta) < 2.5)
+            & (abs(dxy) < 0.1)
+            & (abs(dz) < 0.2)
+            & (loose_id >= 2)
         )
     return mask
+
 
 def isTightElectron(pt, eta, dxy, dz, tight_id, year):
     # 2017/18 pT thresholds adjusted to match monojet, using dedicated ID SFs
     mask = Mask(pt)
-    if year=='2016': # Trigger: HLT_Ele27_WPTight_Gsf_v
+    if year == "2016":  # Trigger: HLT_Ele27_WPTight_Gsf_v
         mask = (
-            pt>40 &
-            abs(eta)<1.4442 &
-            abs(dxy)<0.05 & abs(dz)<0.1 & tight_id==4
+            (pt > 40)
+            & (abs(eta) < 1.4442)
+            & (abs(dxy) < 0.05)
+            & (abs(dz) < 0.1)
+            & (tight_id == 4)
         ) | (
-            pt>40 &
-            abs(eta)>1.5660 & abs(eta)<2.5 &
-            abs(dxy)<0.1 & abs(dz)<0.2 & tight_id==4
+            (pt > 40)
+            & (abs(eta) > 1.5660)
+            & (abs(eta) < 2.5)
+            & (abs(dxy) < 0.1)
+            & (abs(dz) < 0.2)
+            & (tight_id == 4)
         )
-    elif year=='2017': # Trigger: HLT_Ele35_WPTight_Gsf_v
+    elif year == "2017":  # Trigger: HLT_Ele35_WPTight_Gsf_v
         mask = (
-            pt>40 &
-            abs(eta)<1.4442 &
-            abs(dxy)<0.05 & abs(dz)<0.1 & tight_id==4
+            (pt > 40)
+            & (abs(eta) < 1.4442)
+            & (abs(dxy) < 0.05)
+            & (abs(dz) < 0.1)
+            & (tight_id == 4)
         ) | (
-            pt>40 &
-            abs(eta)>1.5660 & abs(eta)<2.5 &
-            abs(dxy)<0.1 & abs(dz)<0.2 & tight_id==4
+            (pt > 40)
+            & (abs(eta) > 1.5660)
+            & (abs(eta) < 2.5)
+            & (abs(dxy) < 0.1)
+            & (abs(dz) < 0.2)
+            & (tight_id == 4)
         )
-    elif year=='2018': # Trigger: HLT_Ele32_WPTight_Gsf_v
+    elif year == "2018":  # Trigger: HLT_Ele32_WPTight_Gsf_v
         mask = (
-            pt>40 &
-            abs(eta)<1.4442 &
-            abs(dxy)<0.05 & abs(dz)<0.1 & tight_id==4
+            (pt > 40)
+            & (abs(eta) < 1.4442)
+            & (abs(dxy) < 0.05)
+            & (abs(dz) < 0.1)
+            & (tight_id == 4)
         ) | (
-            pt>40 &
-            abs(eta)>1.5660 & abs(eta)<2.5 &
-            abs(dxy)<0.1 & abs(dz)<0.2 & tight_id==4
+            (pt > 40)
+            & (abs(eta) > 1.5660)
+            & (abs(eta) < 2.5)
+            & (abs(dxy) < 0.1)
+            & (abs(dz) < 0.2)
+            & (tight_id == 4)
         )
     return mask
+
 
 #######
 ## Muon
@@ -93,74 +127,42 @@ def isTightElectron(pt, eta, dxy, dz, tight_id, year):
 ## https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonSelection#Muon_Isolation
 #######
 
+
 def isLooseMuon(pt, eta, iso, loose_id, year):
     # dxy and dz cuts are missing from med_id; loose isolation is 0.25
     mask = Mask(pt)
-    if year=='2016':
-        mask = (
-            pt>20 &
-            abs(eta)<2.4 &
-            loose_id & iso<0.25
-        )
-    elif year=='2017':
-        mask = (
-            pt>20 &
-            abs(eta)<2.4 &
-            loose_id & iso<0.25
-        )
-    elif year=='2018':
-        mask = (
-            pt>15 &
-            abs(eta)<2.4 &
-            loose_id & iso<0.25
-        )
+    if year == "2016":
+        mask = (pt > 20) & (abs(eta) < 2.4) & loose_id & (iso < 0.25)
+    elif year == "2017":
+        mask = (pt > 20) & (abs(eta) < 2.4) & loose_id & (iso < 0.25)
+    elif year == "2018":
+        mask = (pt > 15) & (abs(eta) < 2.4) & loose_id & (iso < 0.25)
     return mask
+
 
 def isTightMuon(pt, eta, iso, tight_id, year):
     # dxy and dz cuts are baked on tight_id; tight isolation is 0.15
     mask = Mask(pt)
-    if year=='2016':
-        mask = (
-            pt>30 &
-            abs(eta)<2.4 &
-            tight_id & iso<0.15
-        )
-    elif year=='2017':
-        mask = (
-            pt>30 &
-            abs(eta)<2.4 &
-            tight_id & iso<0.15
-        )
-    elif year=='2018':
-        mask = (
-            pt>30 &
-            abs(eta)<2.4 &
-            tight_id & iso<0.15
-        )
+    if year == "2016":
+        mask = (pt > 30) & (abs(eta) < 2.4) & tight_id & (iso < 0.15)
+    elif year == "2017":
+        mask = (pt > 30) & (abs(eta) < 2.4) & tight_id & (iso < 0.15)
+    elif year == "2018":
+        mask = (pt > 30) & (abs(eta) < 2.4) & tight_id & (iso < 0.15)
     return mask
+
 
 def isSoftMuon(pt, eta, iso, tight_id, year):
     # dxy and dz cuts are baked on tight_id; tight isolation is 0.15
     mask = Mask(pt)
-    if year=='2016':
-        mask = (
-            pt>5 &
-            abs(eta)<2.4 &
-            tight_id & iso>0.15
-        )
-    elif year=='2017':
-        mask = (
-            pt>5 &
-            abs(eta)<2.4 &
-            tight_id & iso>0.15
-        )
-    elif year=='2018':
-        mask = (
-            pt>5 &
-            abs(eta)<2.4 &
-            tight_id & iso>0.15
-        )
+    if year == "2016":
+        mask = (pt > 5) & (abs(eta) < 2.4) & tight_id & (iso > 0.15)
+    elif year == "2017":
+        mask = (pt > 5) & (abs(eta) < 2.4) & tight_id & (iso > 0.15)
+    elif year == "2018":
+        mask = (pt > 5) & (abs(eta) < 2.4) & tight_id & (iso > 0.15)
     return mask
+
 
 ######
 ## Tau
@@ -180,30 +182,44 @@ def isSoftMuon(pt, eta, iso, tight_id, year):
 ## 1 = VLoose, 2 = Loose, 4 = Medium, 8 = Tight
 ######
 
+
 def isLooseTau(pt, eta, decayMode, decayModeDMs, ide, idj, idm, year):
     mask = Mask(pt)
-    if year=='2016':
+    if year == "2016":
         mask = (
-            pt>20 &
-            abs(eta)<2.3 &
-            ~(decayMode==5) & ~(decayMode==6) & decayModeDMs &
-            (ide&16)==16 & (idj&4)==4 & (idm&2)==2
+            (pt > 20)
+            & (abs(eta) < 2.3)
+            & ~(decayMode == 5)
+            & ~(decayMode == 6)
+            & decayModeDMs
+            & ((ide & 16) == 16)
+            & ((idj & 4) == 4)
+            & ((idm & 2) == 2)
         )
-    elif year=='2017':
+    elif year == "2017":
         mask = (
-            pt>20 &
-            abs(eta)<2.3 &
-            ~(decayMode==5) & ~(decayMode==6) & decayModeDMs &
-            (ide&16)==16 & (idj&4)==4 & (idm&2)==2
+            (pt > 20)
+            & (abs(eta) < 2.3)
+            & ~(decayMode == 5)
+            & ~(decayMode == 6)
+            & decayModeDMs
+            & ((ide & 16) == 16)
+            & ((idj & 4) == 4)
+            & ((idm & 2) == 2)
         )
-    elif year=='2018':
+    elif year == "2018":
         mask = (
-            pt>20 &
-            abs(eta)<2.3 &
-            ~(decayMode==5) & ~(decayMode==6) & decayModeDMs &
-            (ide&16)==16 & (idj&4)==4 & (idm&2)==2
+            (pt > 20)
+            & (abs(eta) < 2.3)
+            & ~(decayMode == 5)
+            & ~(decayMode == 6)
+            & decayModeDMs
+            & ((ide & 16) == 16)
+            & ((idj & 4) == 4)
+            & ((idm & 2) == 2)
         )
     return mask
+
 
 ######
 ## Photon
@@ -213,49 +229,49 @@ def isLooseTau(pt, eta, decayMode, decayModeDMs, ide, idj, idm, year):
 ## Note: Photon IDs are integers, not bit masks
 ######
 
+
 def isLoosePhoton(pt, eta, loose_id, year):
     mask = Mask(pt)
-    if year=='2016':
+    if year == "2016":
         mask = (
-            pt>20 &
-            ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
-            loose_id>=1
+            (pt > 20)
+            & ~(abs(eta) > 1.4442)
+            & (abs(eta) < 1.5660)
+            & (abs(eta) < 2.5)
+            & (loose_id >= 1)
         )
-    elif year=='2017':
+    elif year == "2017":
         mask = (
-            pt>20 &
-            ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
-            loose_id>=1
+            (pt > 20)
+            & ~(abs(eta) > 1.4442)
+            & (abs(eta) < 1.5660)
+            & (abs(eta) < 2.5)
+            & (loose_id >= 1)
         )
-    elif year=='2018':
+    elif year == "2018":
         mask = (
-            pt>20 &
-            ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
-            loose_id>=1
+            (pt > 20)
+            & ~(abs(eta) > 1.4442)
+            & (abs(eta) < 1.5660)
+            & (abs(eta) < 2.5)
+            & (loose_id >= 1)
         )
     return mask
 
+
 def isTightPhoton(pt, tight_id, year):
-    #isScEtaEB is used (barrel only), so no eta requirement
-    #2017/18 pT requirement adjusted to match monojet, using dedicated ID SFs
-    #Tight photon use medium ID, as in monojet
+    # isScEtaEB is used (barrel only), so no eta requirement
+    # 2017/18 pT requirement adjusted to match monojet, using dedicated ID SFs
+    # Tight photon use medium ID, as in monojet
     mask = Mask(pt)
-    if year=='2016':
-        mask = (
-            pt>200 &
-            tight_id>=2
-        )
-    elif year=='2017':
-        mask = (
-            pt>230 &
-            (tight_id&2)==2
-        )
-    elif year=='2018':
-        mask = (
-            pt>230 &
-            (tight_id&2)==2
-        )
+    if year == "2016":
+        mask = (pt > 200) & (tight_id >= 2)
+    elif year == "2017":
+        mask = (pt > 230) & ((tight_id & 2) == 2)
+    elif year == "2018":
+        mask = (pt > 230) & ((tight_id & 2) == 2)
     return mask
+
 
 ######
 ## Fatjet
@@ -263,13 +279,13 @@ def isTightPhoton(pt, tight_id, year):
 ## Tight working point including lepton veto (TightLepVeto)
 ######
 
+
 def isGoodFatJet(pt, eta, jet_id, nhf, chf):
     mask = (
-        pt>160 &
-        abs(eta)<2.4 &
-        (jet_id&6)==6 & nhf<0.8 & chf>0.1
+        (pt > 160) & (abs(eta) < 2.4) & ((jet_id & 6) == 6) & (nhf < 0.8) & (chf > 0.1)
     )
     return mask
+
 
 ######
 ## Jet
@@ -294,43 +310,38 @@ def isGoodFatJet(pt, eta, jet_id, nhf, chf):
 ## Jet_puId = (passlooseID*4 + passmediumID*2 + passtightID*1).
 ######
 
+
 def isGoodJet(pt, eta, jet_id, pu_id, year):
-    mask = (
-        pt>30 &
-        abs(eta)<2.4 &
-        (jet_id&6)==6
-    )
-    if year=='2016':
-        mask = ((pt>=50) & mask) | ((pt<50) & mask & (pu_id&1)==1)
-    elif year=='2017':
-        mask = ((pt>=50) & mask) | ((pt<50) & mask & (pu_id&4)==4)
-    elif year=='2018':
-        mask = ((pt>=50) & mask) | ((pt<50) & mask & (pu_id&4)==4)
+    mask = (pt > 30) & (abs(eta) < 2.4) & ((jet_id & 6) == 6)
+    if year == "2016":
+        mask = ((pt >= 50) & mask) | ((pt < 50) & mask & ((pu_id & 1) == 1))
+    elif year == "2017":
+        mask = ((pt >= 50) & mask) | ((pt < 50) & mask & ((pu_id & 4) == 4))
+    elif year == "2018":
+        mask = ((pt >= 50) & mask) | ((pt < 50) & mask & ((pu_id & 4) == 4))
     return mask
+
 
 ######
 ## HEM
 ######
 
+
 def isHEMJet(pt, eta, phi):
-    mask = (
-        pt>30 &
-        eta>-3.0 & eta<-1.3 &
-        phi>-1.57 & phi<-0.87
-    )
+    mask = (pt > 30) & (eta > -3.0) & (eta < -1.3) & (phi > -1.57) & (phi < -0.87)
     return mask
 
 
 ids = {}
-ids['isLooseElectron'] = isLooseElectron
-ids['isTightElectron'] = isTightElectron
-ids['isLooseMuon']     = isLooseMuon
-ids['isTightMuon']     = isTightMuon
-ids['isSoftMuon']     = isSoftMuon
-ids['isLooseTau']      = isLooseTau
-ids['isLoosePhoton']   = isLoosePhoton
-ids['isTightPhoton']   = isTightPhoton
-ids['isGoodJet']       = isGoodJet
-ids['isGoodFatJet']    = isGoodFatJet
-ids['isHEMJet']        = isHEMJet
-save(ids, 'data/test_ids.coffea')
+ids["isLooseElectron"] = isLooseElectron
+ids["isTightElectron"] = isTightElectron
+ids["isLooseMuon"] = isLooseMuon
+ids["isTightMuon"] = isTightMuon
+ids["isSoftMuon"] = isSoftMuon
+ids["isLooseTau"] = isLooseTau
+ids["isLoosePhoton"] = isLoosePhoton
+ids["isTightPhoton"] = isTightPhoton
+ids["isGoodJet"] = isGoodJet
+ids["isGoodFatJet"] = isGoodFatJet
+ids["isHEMJet"] = isHEMJet
+save(ids, "data/test_ids.coffea")

--- a/analysis/utils/ids.py
+++ b/analysis/utils/ids.py
@@ -11,10 +11,11 @@ def Mask(pt):
 
 ######
 ## Electron
-## Electron_cutBased  Int_t  cut-based ID Fall17 V2 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
+## Electron_cutBased Int_t cut-based ID Fall17 V2
+## (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
 ## https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
-## loose_electron: loose id, tight_electron: tight id
 ######
+
 def isLooseElectron(pt, eta, dxy, dz, loose_id, year):
     mask = Mask(pt)
     if year=='2016':
@@ -49,8 +50,8 @@ def isLooseElectron(pt, eta, dxy, dz, loose_id, year):
         )
     return mask
 
-#2017/18 pT thresholds adjusted to match monojet, using dedicated ID SFs
 def isTightElectron(pt, eta, dxy, dz, tight_id, year):
+    # 2017/18 pT thresholds adjusted to match monojet, using dedicated ID SFs
     mask = Mask(pt)
     if year=='2016': # Trigger: HLT_Ele27_WPTight_Gsf_v
         mask = (
@@ -86,33 +87,37 @@ def isTightElectron(pt, eta, dxy, dz, tight_id, year):
 
 #######
 ## Muon
+## Muon ID WPs:
+## https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2#Muon_selectors_Since_9_4_X
+## Muon isolation WPs:
 ## https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonSelection#Muon_Isolation
 #######
+
 def isLooseMuon(pt, eta, iso, loose_id, year):
-    #dxy and dz cuts are missing from med_id; loose isolation is 0.25
+    # dxy and dz cuts are missing from med_id; loose isolation is 0.25
     mask = Mask(pt)
     if year=='2016':
         mask = (
             pt>20 &
             abs(eta)<2.4 &
-            loose_id>0 & iso<0.25
+            loose_id & iso<0.25
         )
     elif year=='2017':
         mask = (
             pt>20 &
             abs(eta)<2.4 &
-            loose_id>0 & iso<0.25
+            loose_id & iso<0.25
         )
     elif year=='2018':
         mask = (
             pt>15 &
             abs(eta)<2.4 &
-            loose_id>0 & iso<0.25
+            loose_id & iso<0.25
         )
     return mask
 
 def isTightMuon(pt, eta, iso, tight_id, year):
-    #dxy and dz cuts are baked on tight_id; tight isolation is 0.15
+    # dxy and dz cuts are baked on tight_id; tight isolation is 0.15
     mask = Mask(pt)
     if year=='2016':
         mask = (
@@ -135,7 +140,7 @@ def isTightMuon(pt, eta, iso, tight_id, year):
     return mask
 
 def isSoftMuon(pt, eta, iso, tight_id, year):
-    #dxy and dz cuts are baked on tight_id; tight isolation is 0.15
+    # dxy and dz cuts are baked on tight_id; tight isolation is 0.15
     mask = Mask(pt)
     if year=='2016':
         mask = (
@@ -159,9 +164,22 @@ def isSoftMuon(pt, eta, iso, tight_id, year):
 
 ######
 ## Tau
-## Tau is not used for hadronic monotop
+## https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauIDRecommendationForRun2
+## The decayModeFindingNewDMs: recommended for use with DeepTauv2p1, where decay
+## modes 5 and 6 should be explicitly rejected.
+##
+## Tau_idDeepTau2017v2p1VSe ID working points (bitmask):
+## 1 = VVVLoose, 2 = VVLoose, 4 = VLoose, 8 = Loose,
+## 16 = Medium, 32 = Tight, 64 = VTight, 128 = VVTight
+##
+## Tau_idDeepTau2017v2p1VSjet ID working points (bitmask):
+## 1 = VVVLoose, 2 = VVLoose, 4 = VLoose, 8 = Loose,
+## 16 = Medium, 32 = Tight, 64 = VTight, 128 = VVTight
+##
+## Tau_idDeepTau2017v2p1VSmu ID working points (bitmask):
+## 1 = VLoose, 2 = Loose, 4 = Medium, 8 = Tight
 ######
-#bitmask 1 = VVLoose, 2 = VLoose, 4 = Loose, 8 = Medium, 16 = Tight, 32 = VTight, 64 = VVTight
+
 def isLooseTau(pt, eta, decayMode, decayModeDMs, ide, idj, idm, year):
     mask = Mask(pt)
     if year=='2016':
@@ -189,10 +207,12 @@ def isLooseTau(pt, eta, decayMode, decayModeDMs, ide, idj, idm, year):
 
 ######
 ## Photon
+## https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2
+## Photon_cutBased Int_t cut-based ID bitmap, Fall17V2,
+## (0:fail, 1:loose, 2:medium, 3:tight)
+## Note: Photon IDs are integers, not bit masks
 ######
-#Photon_cutBased Int_t "cut-based spring16-V2p2 ID (0:fail, 1:loose, 2:medium, 3:tight" for 2016 NanoAOD
-#Photon_cutBasedBitmap  Int_t   cut-based ID bitmap, 2^(0:loose, 1:medium, 2:tight)
-#Photon IDs:  https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2?rev=36
+
 def isLoosePhoton(pt, eta, loose_id, year):
     mask = Mask(pt)
     if year=='2016':
@@ -205,13 +225,13 @@ def isLoosePhoton(pt, eta, loose_id, year):
         mask = (
             pt>20 &
             ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
-            (loose_id&1)==1
+            loose_id>=1
         )
     elif year=='2018':
         mask = (
             pt>20 &
             ~(abs(eta)>1.4442) & abs(eta)<1.5660 & abs(eta)<2.5 &
-            (loose_id&1)==1
+            loose_id>=1
         )
     return mask
 
@@ -242,10 +262,11 @@ def isTightPhoton(pt, tight_id, year):
 ## https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVUL
 ## Tight working point including lepton veto (TightLepVeto)
 ######
+
 def isGoodFatJet(pt, eta, jet_id, nhf, chf):
     mask = (
         pt>160 &
-        abs(eta)<2.4) &
+        abs(eta)<2.4 &
         (jet_id&6)==6 & nhf<0.8 & chf>0.1
     )
     return mask
@@ -272,6 +293,7 @@ def isGoodFatJet(pt, eta, jet_id, nhf, chf):
 ## For 2017 UL and 2018 UL,
 ## Jet_puId = (passlooseID*4 + passmediumID*2 + passtightID*1).
 ######
+
 def isGoodJet(pt, eta, jet_id, pu_id, year):
     mask = (
         pt>30 &


### PR DESCRIPTION
Update particle IDs for UL and update inline documentation with links to twikis from which this information was obtained. This addresses Issue 
- https://github.com/mcremone/decaf/issues/73 

in combination with commits 7a5f023* and c542b9f from PR https://github.com/mcremone/decaf/pull/75.

Jet PU ID is now dependent on year due to a bug in CMSSW. See comment https://github.com/mcremone/decaf/issues/73#issuecomment-1853136589.

for more information (click on drop downs for more details). Functions that use the function `isGoodJet()` also need to be updated as mentioned at the end of another comment https://github.com/mcremone/decaf/issues/73#issuecomment-1854603481.

---

*Large commit and very slow to load. See [`ids.py`](https://github.com/mcremone/decaf/blob/7a5f0239e70df58e13907c5dfd70dfdc012f2774/analysis/utils/ids.py) @ commit 7a5f023 here.