### PR TITLE
Update decaf coffea

### DIFF
--- a/setup_lcg.sh
+++ b/setup_lcg.sh
@@ -2,7 +2,7 @@
 
 source env_lcg.sh
 
-#pip install --user coffea==0.7.12
+pip install --user coffea==0.7.20
 pip install --user https://github.com/mcremone/rhalphalib/archive/py3.zip
 pip install --user xxhash
 # progressbar, sliders, etc.


### PR DESCRIPTION
(Pun intended) Update setup_lcg.sh to use coffea==0.7.20, as it is the latest version that actually installs successfully with pip.