### PR TITLE
fix merge.py indent error

### DIFF
--- a/analysis/merge.py
+++ b/analysis/merge.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     parser.add_option('-v', '--variable', help='variable', dest='variable', default=None)
     parser.add_option('-e', '--exclude', help='exclude', dest='exclude', default=None)
     parser.add_option('-p', '--postprocess', action='store_true', dest='postprocess')
-     (options, args) = parser.parse_args()
+    (options, args) = parser.parse_args()
 
     patch_mp_connection_bpo_17560()
     if options.postprocess:


### PR DESCRIPTION
There was an indenting error in `merge.py`. It now runs correctly